### PR TITLE
Remove passing lane and parameters from cmd args

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/fastlane/swift/SocketClient.swift
+++ b/fastlane/swift/SocketClient.swift
@@ -307,7 +307,7 @@ extension SocketClient: StreamDelegate {
             }
 
         case let .failure(failureInformation, failureClass, failureMessage):
-            LaneFile.fastfileInstance?.onError(currentLane: ArgumentProcessor(args: CommandLine.arguments).currentLane, errorInfo: failureInformation.joined(), errorClass: failureClass, errorMessage: failureMessage)
+            LaneFile.fastfileInstance?.onError(currentLane: currentLane!, errorInfo: failureInformation.joined(), errorClass: failureClass, errorMessage: failureMessage)
             socketDelegate?.commandExecuted(serverResponse: .serverError) {
                 $0.writeSemaphore.signal()
                 self.handleFailure(message: failureMessage.map { m in [m] + failureInformation } ?? failureInformation)


### PR DESCRIPTION
To run a `fastlane` _runner_ without specifying `lane` and its parameters.